### PR TITLE
Fix measurement code causes E1017 and type mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,10 @@ END
   return luaeval('sum')
 endfunc
 
-def VimNew()
+def VimNew(): number
   let sum = 0
   for i in range(1, 2999999)
-    let sum += i
+    sum += i
   endfor
   return sum
 enddef


### PR DESCRIPTION
Hi,

thank you for exciting new-year present! I tried the measurement code in README.md on my local and noticed it caused an error as follows:

```
E1017: Variable already declared: sum
```

Though I'm not fully understanding the grammar, it seems that `let` is used for declaration in new syntax. `is_decl` is set to true on `:let` or `:const` so I guess assignment to existing variable should be in `var = expr` style.

https://github.com/brammool/vim9/blob/f9a84f6e12b633006b0bbc82101dee2c994c478e/src/vim9compile.c#L2747

After this fix above E1017 no longer occurred.